### PR TITLE
Fix/sitemap fetch failed & improve date format

### DIFF
--- a/src/app/(root)/user/sitemap.ts
+++ b/src/app/(root)/user/sitemap.ts
@@ -1,11 +1,12 @@
+"use cache";
+import { cacheLife } from "next/cache";
 import { createClientWithoutCookies } from "@/database/serverWithoutCookie";
 import { outputBaseUrl } from "@/lib/outputBaseUrl";
 import type { MetadataRoute } from "next";
 
-export const revalidate = 86400; // Re-cache every 24 hours
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  cacheLife("days");
   const baseUrl = outputBaseUrl().toString();
-
   try {
     const supabase = createClientWithoutCookies();
 


### PR DESCRIPTION
fix: enable caching for user sitemap generation

there is a fetch pre-render problem in nextjs buildtime. Because supabase does not use fetch directly , it does not work with "auto cache" . Using un_stable_cache or stable - "use cache" directive would solve that
cloese #5 


 convert profile.updated_at to Date object in sitemap