### PR TITLE
feat: add leading relaxed in global

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,10 +1,27 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-* {
-  line-height: 1.625;
+
+@layer utilities {
+  /* leading-relaxed (for myanmar language , this is necessary)
+  As tailwind text-* has its own line-height
+  */
+  .text-sm {
+    line-height: 1.625;
+  }
+  .text-base {
+    line-height: 1.625;
+  }
+  .text-xs {
+    line-height: 1.625;
+  }
 }
+
 @layer base {
+  html,
+  body {
+    line-height: 1.625;
+  }
   :root {
     --background: #e4ecf3;
     --foreground: #07080a;

--- a/src/ui/footer/Footer.tsx
+++ b/src/ui/footer/Footer.tsx
@@ -10,9 +10,7 @@ async function Footer() {
       <div className="grid  px-5 grid-cols-1 gap-8">
         <div className="space-y-4 sm:col-span-2 lg:col-auto col-auto">
           <h3 className="font-bold text-lg">{b("noti")}</h3>
-          <p className="text-ink-400 text-sm leading-relaxed">
-            {b("footerNoti")}
-          </p>
+          <p className="text-ink-400 text-sm">{b("footerNoti")}</p>
         </div>
 
         <div className="space-y-4">
@@ -47,7 +45,7 @@ async function Footer() {
 
         <div className="space-y-4">
           <h3 className="font-bold text-lg">{b("contact")}</h3>
-          <p className="text-ink-400 text-sm leading-relaxed"></p>
+          <p className="text-ink-400 text-sm"></p>
           <div className="flex flex-col space-y-3">
             <Link
               target="_"

--- a/src/ui/general/DialogParent/InfoBox/InfoMessage.tsx
+++ b/src/ui/general/DialogParent/InfoBox/InfoMessage.tsx
@@ -24,7 +24,7 @@ function InfoMessage() {
           <Dialog.Title className="-mt-1.5 mb-2 text-lg font-medium">
             {b("noti")}
           </Dialog.Title>
-          <Dialog.Description className="mb-6 text-base break-all leading-relaxed ">
+          <Dialog.Description className="mb-6 text-base break-all">
             {formSubmitMsg}
           </Dialog.Description>
           <div className="flex justify-end gap-4">

--- a/src/ui/general/DialogParent/notiReset/TabRootReset.tsx
+++ b/src/ui/general/DialogParent/notiReset/TabRootReset.tsx
@@ -32,7 +32,7 @@ function TabRootReset() {
           <AlertDialog.Title className="-mt-1.5 mb-3 text-lg font-medium">
             {b("noti")}
           </AlertDialog.Title>
-          <AlertDialog.Description className="mb-6 text-base leading-relaxed break-all ">
+          <AlertDialog.Description className="mb-6 text-base break-all ">
             {w("unsaved")}
           </AlertDialog.Description>
           <div className="flex justify-end gap-4">

--- a/src/ui/general/DialogParent/profileDelete/ProfileDelete.tsx
+++ b/src/ui/general/DialogParent/profileDelete/ProfileDelete.tsx
@@ -27,7 +27,7 @@ function ProfileDelete() {
           <AlertDialog.Title className="-mt-1.5 mb-3 text-lg font-medium">
             {b("noti")}
           </AlertDialog.Title>
-          <AlertDialog.Description className="mb-6 text-base leading-relaxed break-all ">
+          <AlertDialog.Description className="mb-6 text-base break-all ">
             {w("deleteProfileWarning")}
           </AlertDialog.Description>
           <div className="flex justify-end gap-4">

--- a/src/ui/general/DialogParent/userDelete/UserDelete.tsx
+++ b/src/ui/general/DialogParent/userDelete/UserDelete.tsx
@@ -27,7 +27,7 @@ function UserDelete() {
           <AlertDialog.Title className="-mt-1.5 mb-3 text-lg font-medium">
             {b("noti")}
           </AlertDialog.Title>
-          <AlertDialog.Description className="mb-6 text-base leading-relaxed break-all ">
+          <AlertDialog.Description className="mb-6 text-base  break-all ">
             {w("deleteUserWarning")}
           </AlertDialog.Description>
           <div className="flex justify-end gap-4">

--- a/src/ui/profile/Input/AutoResizeTextArea.tsx
+++ b/src/ui/profile/Input/AutoResizeTextArea.tsx
@@ -214,7 +214,7 @@ export default function AutoResizeTextArea({
             <Dialog.Title className="-mt-1.5 mb-1 text-lg font-medium">
               {b("noti")}
             </Dialog.Title>
-            <Dialog.Description className="mb-6 text-base leading-relaxed break-all  ">
+            <Dialog.Description className="mb-6 text-base  break-all  ">
               {t("3isMax")}
             </Dialog.Description>
             <div className="flex justify-end gap-4">

--- a/src/ui/profile/viewComponent/Friendliness.tsx
+++ b/src/ui/profile/viewComponent/Friendliness.tsx
@@ -8,10 +8,10 @@ function Friendliness({
   const friendnesssPercentage = Number(text_select_friendness) * 20;
   return (
     <div className="h-16 flex flex-col justify-center gap-1">
-      <h3 className="leading-relaxed  font-semibold">
+      <h3 className="font-semibold">
         {label} {`(${friendnesssPercentage}%)`}
       </h3>
-      <div className="leading-relaxed">
+      <div>
         <div className="bg-cardcontainer border border-gray-400 w-full  h-2 relative">
           <span
             className="h-full bg-semicontainer block"

--- a/src/ui/profile/viewComponent/MultipleList.tsx
+++ b/src/ui/profile/viewComponent/MultipleList.tsx
@@ -13,9 +13,7 @@ function MultipleList({
       <div className="w-fit flex flex-wrap gap-1   break-all ">
         {items.map((item) => (
           <div key={item.id} className="p-[2px] rounded-lg bg-semicontainer ">
-            <div className="bg-zonecontainer  leading-relaxed p-2 rounded-lg">
-              {item.name}
-            </div>
+            <div className="bg-zonecontainer p-2 rounded-lg">{item.name}</div>
           </div>
         ))}
       </div>


### PR DESCRIPTION
As the current approach is hard to mantain, eg : i have to add leading-relaxed to text-sm , text-base and also it does not have auto default line-height , add overwrite line-height to tailwind text-* utility
fixed (#14 )